### PR TITLE
fix for ios not displaying full screen properly

### DIFF
--- a/ios/RCTVideo.m
+++ b/ios/RCTVideo.m
@@ -801,7 +801,6 @@ static NSString *const timedMetadata = @"timedMetadata";
   [super layoutSubviews];
   if( _controls )
   {
-    _playerViewController.view.frame = self.bounds;
 
     // also adjust all subviews of contentOverlayView
     for (UIView* subview in _playerViewController.contentOverlayView.subviews) {


### PR DESCRIPTION
fix to allow video player to actually take up full screen and not display off screen while in landscape