### PR TITLE
bug/destroyFullscreenPlayer

### DIFF
--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/CustomFullscreenPlayer.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/CustomFullscreenPlayer.java
@@ -55,6 +55,8 @@ public class CustomFullscreenPlayer extends Activity {
     public void onDestroy() {
         super.onDestroy();
         this.stopTracking();
+        player.clearVideoSurface();
+        player.release();
     }
 
     private void createExoPlayer() {


### PR DESCRIPTION
- making sure that the player is cleared and released when activity is destroyed by screen rotation