### PR TITLE
Expose rotation degrees from video metadata.

### DIFF
--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -667,8 +667,9 @@ class ReactExoplayerView extends FrameLayout implements
             Format videoFormat = player.getVideoFormat();
             int width = videoFormat != null ? videoFormat.width : 0;
             int height = videoFormat != null ? videoFormat.height : 0;
+            int rotationDegress = videoFormat != null ? videoFormat.rotationDegrees : 0;
             eventEmitter.load(player.getDuration(), player.getCurrentPosition(), width, height,
-                    getAudioTrackInfo(), getTextTrackInfo(), getVideoTrackInfo());
+                    getAudioTrackInfo(), getTextTrackInfo(), getVideoTrackInfo(), rotationDegress);
         }
     }
 

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/VideoEventEmitter.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/VideoEventEmitter.java
@@ -121,6 +121,7 @@ class VideoEventEmitter {
     private static final String EVENT_PROP_HAS_AUDIO_FOCUS = "hasAudioFocus";
     private static final String EVENT_PROP_IS_BUFFERING = "isBuffering";
     private static final String EVENT_PROP_PLAYBACK_RATE = "playbackRate";
+    private static final String EVENT_PROP_ROTATION_DEGREES = "rotationDegrees";
 
     private static final String EVENT_PROP_ERROR = "error";
     private static final String EVENT_PROP_ERROR_STRING = "errorString";
@@ -142,7 +143,7 @@ class VideoEventEmitter {
     }
 
     void load(double duration, double currentPosition, int videoWidth, int videoHeight,
-              WritableArray audioTracks, WritableArray textTracks, WritableArray videoTracks) {
+              WritableArray audioTracks, WritableArray textTracks, WritableArray videoTracks, int rotationDegrees) {
         WritableMap event = Arguments.createMap();
         event.putDouble(EVENT_PROP_DURATION, duration / 1000D);
         event.putDouble(EVENT_PROP_CURRENT_TIME, currentPosition / 1000D);
@@ -150,11 +151,13 @@ class VideoEventEmitter {
         WritableMap naturalSize = Arguments.createMap();
         naturalSize.putInt(EVENT_PROP_WIDTH, videoWidth);
         naturalSize.putInt(EVENT_PROP_HEIGHT, videoHeight);
-        if (videoWidth > videoHeight) {
-            naturalSize.putString(EVENT_PROP_ORIENTATION, "landscape");
-        } else {
-            naturalSize.putString(EVENT_PROP_ORIENTATION, "portrait");
+        String orientation = videoWidth > videoHeight ? "landscape" : "portrait";
+        // Confirm orientation by checking the degrees
+        if (rotationDegrees == 90 || rotationDegrees == 270) {
+            orientation = "portrait";
         }
+        naturalSize.putString(EVENT_PROP_ORIENTATION, orientation);
+        naturalSize.putInt(EVENT_PROP_ROTATION_DEGREES, rotationDegrees);
         event.putMap(EVENT_PROP_NATURAL_SIZE, naturalSize);
 
         event.putArray(EVENT_PROP_VIDEO_TRACKS, videoTracks);

--- a/ios/Video/RCTVideo.m
+++ b/ios/Video/RCTVideo.m
@@ -619,6 +619,7 @@ static int const RCTVideoUnset = -1;
         NSObject *width = @"undefined";
         NSObject *height = @"undefined";
         NSString *orientation = @"undefined";
+        int rotationDegrees = 0;
         
         if ([_playerItem.asset tracksWithMediaType:AVMediaTypeVideo].count > 0) {
           AVAssetTrack *videoTrack = [[_playerItem.asset tracksWithMediaType:AVMediaTypeVideo] objectAtIndex:0];
@@ -632,6 +633,12 @@ static int const RCTVideoUnset = -1;
           {
             orientation = @"landscape";
           } else {
+            orientation = @"portrait";
+          }
+          double angle = atan2(preferredTransform.b, preferredTransform.a);
+          rotationDegrees = angle * 180 / M_PI;
+          // confirm if video is in portrait by checking the degrees
+          if (rotationDegrees == 90 || rotationDegrees == 270) {
             orientation = @"portrait";
           }
         }
@@ -648,7 +655,8 @@ static int const RCTVideoUnset = -1;
                              @"naturalSize": @{
                                  @"width": width,
                                  @"height": height,
-                                 @"orientation": orientation
+                                 @"orientation": orientation,
+                                 @"rotationDegrees": [NSNumber numberWithInt:rotationDegrees]
                                  },
                              @"audioTracks": [self getAudioTrackInfo],
                              @"textTracks": [self getTextTrackInfo],


### PR DESCRIPTION
In some platforms, like Android, the value of the width and height
is not representative of the actual orientation of the video.
To accurately detect if the video is in landscape or portrait mode
we need to also check the value of the degrees.

